### PR TITLE
fix: cursor disppear when in handle bar highlight

### DIFF
--- a/ui/universe-editor/js/core-editor.js
+++ b/ui/universe-editor/js/core-editor.js
@@ -113,8 +113,12 @@ export class CoreEditor {
             line-height: var(--line-height);
         }
     
-        .editor, pre, code {
+        pre, code {
             z-index: 2;
+        }
+
+        textarea.editor {
+            z-index: 3;
         }
     
         .editor {


### PR DESCRIPTION
Text area cursor disappear when in handle bar highlight. It is very hard to type without cursor. This cause because the z-index of textarea and the highlight are the same.

------

Before

https://github.com/user-attachments/assets/36572f9e-70d1-4862-8a99-cc4c7ae80a51

After


https://github.com/user-attachments/assets/bf3439ff-31bd-444e-b524-09364f07a62c

